### PR TITLE
Upgrade: Bump elliptic from 6.5.7 to 6.6.0

Bumps [elliptic](https://github.com/indutny/elliptic) from 6.5.7 to 6.6.0.
- [Commits](https://github.com/indutny/elliptic/compare/v6.5.7...v6.6.0)

---
updated-dependencies:
- dependency-name: elliptic
  dependency-type: indirect
...

Signed-off-by: dependabot[bot] <support@github.com>

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3994,9 +3994,9 @@ elegant-spinner@^1.0.1:
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
 elliptic@^6.5.3, elliptic@^6.5.5:
-  version "6.5.7"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.7.tgz#8ec4da2cb2939926a1b9a73619d768207e647c8b"
-  integrity sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.0.tgz#5919ec723286c1edf28685aa89261d4761afa210"
+  integrity sha512-dpwoQcLc/2WLQvJvLRHKZ+f9FgOdjnq11rurqwekGQygGPsYSK29OMMD2WalatiqQ+XGFDglTNixpPfI+lpaAA==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"


### PR DESCRIPTION
<!--

Read our pull request guide:
https://webhint.io/docs/contributor-guide/getting-started/pull-requests/

For the following items put an "x" between the square brackets
(i.e. [x]) if you completed the associated item.

-->

## Pull request checklist

Make sure you:

- [ ] Signed the [Contributor License Agreement](https://openjsf.org/cla) (after creating PR)
- [ ] Followed the [commit message guidelines](https://webhint.io/docs/contributor-guide/getting-started/pull-requests/#commit-messages)

For non-trivial changes, please make sure you also:

- [ ] Added/Updated related documentation.
- [ ] Added/Updated related tests.

## Short description of the change(s)

<!--

If this is a non-trivial change, include information such as what
benefits this change brings as well as possible drawbacks.

If this fixes an existing issue, include the relevant issue number(s).

Thank you for taking the time to open this PR!

-->
